### PR TITLE
Fix git root detection to support worktrees and submodules

### DIFF
--- a/lua/oil-git/git.lua
+++ b/lua/oil-git/git.lua
@@ -23,13 +23,11 @@ function M.invalidate_cache()
 end
 
 function M.get_root(dir)
-	-- Check for .git as a file first (worktrees, submodules)
 	local git_dir = vim.fn.findfile(".git", dir .. ";")
 	if git_dir ~= "" then
 		return vim.fn.fnamemodify(git_dir, ":p:h"), "findfile"
 	end
 
-	-- Check for .git as a directory
 	git_dir = vim.fn.finddir(".git", dir .. ";")
 	if git_dir ~= "" then
 		return vim.fn.fnamemodify(git_dir, ":p:h:h"), "finddir"
@@ -48,7 +46,6 @@ function M.get_root(dir)
 end
 
 function M.get_root_async(dir, callback)
-	-- Check for .git as a file first (worktrees, submodules)
 	local git_dir = vim.fn.findfile(".git", dir .. ";")
 	if git_dir ~= "" then
 		local root = vim.fn.fnamemodify(git_dir, ":p:h")
@@ -57,7 +54,6 @@ function M.get_root_async(dir, callback)
 		return
 	end
 
-	-- Check for .git as a directory
 	git_dir = vim.fn.finddir(".git", dir .. ";")
 	if git_dir ~= "" then
 		local root = vim.fn.fnamemodify(git_dir, ":p:h:h")

--- a/lua/oil-git/git.lua
+++ b/lua/oil-git/git.lua
@@ -23,7 +23,14 @@ function M.invalidate_cache()
 end
 
 function M.get_root(dir)
-	local git_dir = vim.fn.finddir(".git", dir .. ";")
+	-- Check for .git as a file first (worktrees, submodules)
+	local git_dir = vim.fn.findfile(".git", dir .. ";")
+	if git_dir ~= "" then
+		return vim.fn.fnamemodify(git_dir, ":p:h"), "findfile"
+	end
+
+	-- Check for .git as a directory
+	git_dir = vim.fn.finddir(".git", dir .. ";")
 	if git_dir ~= "" then
 		return vim.fn.fnamemodify(git_dir, ":p:h:h"), "finddir"
 	end
@@ -41,7 +48,17 @@ function M.get_root(dir)
 end
 
 function M.get_root_async(dir, callback)
-	local git_dir = vim.fn.finddir(".git", dir .. ";")
+	-- Check for .git as a file first (worktrees, submodules)
+	local git_dir = vim.fn.findfile(".git", dir .. ";")
+	if git_dir ~= "" then
+		local root = vim.fn.fnamemodify(git_dir, ":p:h")
+		util.debug_log("verbose", "Git root found via findfile: %s", root)
+		callback(root)
+		return
+	end
+
+	-- Check for .git as a directory
+	git_dir = vim.fn.finddir(".git", dir .. ";")
 	if git_dir ~= "" then
 		local root = vim.fn.fnamemodify(git_dir, ":p:h:h")
 		util.debug_log("verbose", "Git root found via finddir: %s", root)
@@ -49,7 +66,11 @@ function M.get_root_async(dir, callback)
 		return
 	end
 
-	util.debug_log("verbose", "finddir failed, trying git command for: %s", dir)
+	util.debug_log(
+		"verbose",
+		"finddir/findfile failed, trying git command for: %s",
+		dir
+	)
 
 	local stdout = uv.new_pipe(false)
 	local output_parts = {}


### PR DESCRIPTION
Updated `get_root()` and `get_root_async()` to check for .git as a file before checking as a directory. This fixes git root detection for worktrees and submodules where .git is a file rather than a directory.

originated from https://github.com/benomahony/oil-git.nvim/pull/16