### PR TITLE
feat(config): add can_use_signcolumn callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ require("oil-git").setup({
   show_ignored_files = false,       -- Show ignored file status
   show_ignored_directories = false, -- Show ignored directory status
   symbol_position = "eol",  -- "eol", "signcolumn", or "none"
+  can_use_signcolumn = nil,  -- Optional callback(bufnr): nil|bool|string
   ignore_gitsigns_update = false,   -- Ignore GitSignsUpdate events (fallback for flickering)
   debug = false,            -- false, "minimal", or "verbose"
 
@@ -120,6 +121,17 @@ require("oil-git").setup({
   },
 })
 ```
+
+### Signcolumn callback
+
+When `symbol_position = "signcolumn"`, you can optionally provide
+`can_use_signcolumn = function(bufnr) ... end` to control behavior per buffer.
+
+- Return `nil` to use the default oil.nvim compatibility check.
+- Return `true` to force signcolumn symbols on.
+- Return `false` to force signcolumn symbols off.
+- Return a string (for example `"yes:2"`) to force signcolumn symbols on and
+  set the window `signcolumn` value when symbols are present.
 
 ## Git Status Reference
 

--- a/lua/oil-git/config.lua
+++ b/lua/oil-git/config.lua
@@ -11,6 +11,7 @@ local default_config = {
 	show_ignored_files = false,
 	show_ignored_directories = false,
 	symbol_position = "eol",
+	can_use_signcolumn = nil,
 	ignore_gitsigns_update = false,
 	debug = false,
 	symbols = {

--- a/lua/oil-git/highlights.lua
+++ b/lua/oil-git/highlights.lua
@@ -96,10 +96,13 @@ function M.clear(bufnr)
 
 	local cfg = config.get()
 	if
-		cfg.can_use_signcolumn
-		and cfg.symbol_position == constants.SYMBOL_POSITIONS.SIGNCOLUMN
+		cfg.symbol_position == constants.SYMBOL_POSITIONS.SIGNCOLUMN
+		and cfg.can_use_signcolumn
 	then
-		set_signcolumn(bufnr, "no")
+		local ok, sc_value = pcall(cfg.can_use_signcolumn, bufnr)
+		if ok and type(sc_value) == "string" then
+			set_signcolumn(bufnr, "no")
+		end
 	end
 end
 
@@ -147,17 +150,40 @@ local function apply_to_buffer(
 	local show_ignored_directories = cfg.show_ignored_directories
 	local symbol_position = cfg.symbol_position
 	local can_use_signcolumn_fn = cfg.can_use_signcolumn
+	local can_use_signcolumn_override = nil
 	local manage_signcolumn = false
 	local scl_value = nil
 
-	if can_use_signcolumn_fn and symbol_position == constants.SYMBOL_POSITIONS.SIGNCOLUMN then
-		scl_value = can_use_signcolumn_fn(bufnr)
-		manage_signcolumn = type(scl_value) == "string"
+	if
+		can_use_signcolumn_fn
+		and symbol_position == constants.SYMBOL_POSITIONS.SIGNCOLUMN
+	then
+		local ok, callback_value = pcall(can_use_signcolumn_fn, bufnr)
+		if ok then
+			if type(callback_value) == "string" then
+				scl_value = callback_value
+				manage_signcolumn = true
+				can_use_signcolumn_override = true
+			elseif type(callback_value) == "boolean" then
+				can_use_signcolumn_override = callback_value
+			end
+		else
+			util.debug_log(
+				"minimal",
+				"can_use_signcolumn callback failed: %s",
+				callback_value
+			)
+		end
 	end
 
-	local use_signcolumn = symbol_position
-			== constants.SYMBOL_POSITIONS.SIGNCOLUMN
-		and (manage_signcolumn or scl_value or can_use_signcolumn())
+	local use_signcolumn = false
+	if symbol_position == constants.SYMBOL_POSITIONS.SIGNCOLUMN then
+		if can_use_signcolumn_override ~= nil then
+			use_signcolumn = can_use_signcolumn_override
+		else
+			use_signcolumn = can_use_signcolumn()
+		end
+	end
 	local symbols_not_disabled = symbol_position
 		~= constants.SYMBOL_POSITIONS.NONE
 	local file_symbols = cfg.symbols.file

--- a/lua/oil-git/highlights.lua
+++ b/lua/oil-git/highlights.lua
@@ -152,12 +152,12 @@ local function apply_to_buffer(
 
 	if can_use_signcolumn_fn and symbol_position == constants.SYMBOL_POSITIONS.SIGNCOLUMN then
 		scl_value = can_use_signcolumn_fn(bufnr)
-		manage_signcolumn = scl_value and true or false
+		manage_signcolumn = type(scl_value) == "string"
 	end
 
 	local use_signcolumn = symbol_position
 			== constants.SYMBOL_POSITIONS.SIGNCOLUMN
-		and (manage_signcolumn or can_use_signcolumn())
+		and (manage_signcolumn or scl_value or can_use_signcolumn())
 	local symbols_not_disabled = symbol_position
 		~= constants.SYMBOL_POSITIONS.NONE
 	local file_symbols = cfg.symbols.file

--- a/lua/oil-git/highlights.lua
+++ b/lua/oil-git/highlights.lua
@@ -276,7 +276,7 @@ local function apply_to_buffer(
 					hl.line_idx,
 					0,
 					{
-						sign_text = hl.symbol:sub(1, 2),
+						sign_text = vim.fn.strcharpart(hl.symbol, 0, 2),
 						sign_hl_group = hl.hl_group,
 					}
 				)

--- a/lua/oil-git/highlights.lua
+++ b/lua/oil-git/highlights.lua
@@ -60,6 +60,13 @@ local function can_use_signcolumn()
 	return true
 end
 
+local function set_signcolumn(bufnr, value)
+	local winid = vim.fn.bufwinid(bufnr)
+	if winid ~= -1 then
+		vim.wo[winid].signcolumn = value
+	end
+end
+
 function M.setup()
 	signcolumn_cache = nil
 	local cfg = config.get_raw()
@@ -86,6 +93,14 @@ function M.clear(bufnr)
 		buffer_ns_ids[bufnr] = nil
 	end
 	buffer_highlight_hashes[bufnr] = nil
+
+	local cfg = config.get()
+	if
+		cfg.can_use_signcolumn
+		and cfg.symbol_position == constants.SYMBOL_POSITIONS.SIGNCOLUMN
+	then
+		set_signcolumn(bufnr, "no")
+	end
 end
 
 function M.on_buf_delete(bufnr)
@@ -131,9 +146,18 @@ local function apply_to_buffer(
 	local show_ignored_files = cfg.show_ignored_files
 	local show_ignored_directories = cfg.show_ignored_directories
 	local symbol_position = cfg.symbol_position
+	local can_use_signcolumn_fn = cfg.can_use_signcolumn
+	local manage_signcolumn = false
+	local scl_value = nil
+
+	if can_use_signcolumn_fn and symbol_position == constants.SYMBOL_POSITIONS.SIGNCOLUMN then
+		scl_value = can_use_signcolumn_fn(bufnr)
+		manage_signcolumn = scl_value and true or false
+	end
+
 	local use_signcolumn = symbol_position
 			== constants.SYMBOL_POSITIONS.SIGNCOLUMN
-		and can_use_signcolumn()
+		and (manage_signcolumn or can_use_signcolumn())
 	local symbols_not_disabled = symbol_position
 		~= constants.SYMBOL_POSITIONS.NONE
 	local file_symbols = cfg.symbols.file
@@ -298,6 +322,10 @@ local function apply_to_buffer(
 			end
 			symbol_count = symbol_count + 1
 		end
+	end
+
+	if manage_signcolumn then
+		set_signcolumn(bufnr, symbol_count > 0 and scl_value or "no")
 	end
 
 	buffer_ns_ids[bufnr] = ns_id

--- a/tests/plenary/config_spec.lua
+++ b/tests/plenary/config_spec.lua
@@ -133,6 +133,7 @@ describe("config", function()
 			assert.is_false(cfg.show_ignored_files)
 			assert.is_false(cfg.show_ignored_directories)
 			assert.equals("eol", cfg.symbol_position)
+			assert.is_nil(cfg.can_use_signcolumn)
 			assert.is_false(cfg.ignore_gitsigns_update)
 			assert.is_false(cfg.debug)
 

--- a/tests/plenary/highlights_spec.lua
+++ b/tests/plenary/highlights_spec.lua
@@ -10,6 +10,22 @@ describe("highlights", function()
 		highlights = require("oil-git.highlights")
 	end)
 
+	local function get_status_extmarks(bufnr)
+		local ns_id = vim.api.nvim_create_namespace("oil_git_status_" .. bufnr)
+		local ok, extmarks = pcall(
+			vim.api.nvim_buf_get_extmarks,
+			bufnr,
+			ns_id,
+			0,
+			-1,
+			{ details = true }
+		)
+		if not ok then
+			return {}
+		end
+		return extmarks
+	end
+
 	after_each(function()
 		helpers.close_oil_buffers()
 	end)
@@ -164,6 +180,106 @@ describe("highlights", function()
 					helpers.cleanup(repo_dir)
 				end
 			)
+
+			describe("signcolumn callback", function()
+				local repo_dir
+
+				before_each(function()
+					repo_dir = helpers.create_temp_git_repo()
+					helpers.create_and_commit_file(
+						repo_dir,
+						"file.lua",
+						"-- committed"
+					)
+					helpers.create_file(repo_dir, "file.lua", "-- modified")
+					helpers.wait_for(function()
+						return helpers.get_git_status(repo_dir) ~= ""
+					end, 1000)
+				end)
+
+				after_each(function()
+					helpers.close_oil_buffers()
+					helpers.cleanup(repo_dir)
+				end)
+
+				it(
+					"should respect false callback and avoid sign_text",
+					function()
+						config.setup({
+							symbol_position = "signcolumn",
+							can_use_signcolumn = function()
+								return false
+							end,
+						})
+						highlights.setup()
+
+						local oil = require("oil")
+						oil.open(repo_dir)
+
+						local ready = helpers.wait_for(function()
+							return vim.bo.filetype == "oil"
+						end, 2000)
+
+						if not ready then
+							return
+						end
+
+						local bufnr = vim.api.nvim_get_current_buf()
+						helpers.wait_for_oil_entries(bufnr, 2000)
+						highlights.apply(bufnr, repo_dir .. "/")
+
+						local has_marks = helpers.wait_for(function()
+							return #get_status_extmarks(bufnr) > 0
+						end, 2000)
+						assert.is_true(has_marks)
+
+						local marks = get_status_extmarks(bufnr)
+						local has_sign = false
+						local has_virt = false
+
+						for _, mark in ipairs(marks) do
+							local details = mark[4] or {}
+							if details.sign_text then
+								has_sign = true
+							end
+							if details.virt_text then
+								has_virt = true
+							end
+						end
+
+						assert.is_false(has_sign)
+						assert.is_true(has_virt)
+					end
+				)
+
+				it("should not crash when callback throws", function()
+					config.setup({
+						symbol_position = "signcolumn",
+						can_use_signcolumn = function()
+							error("callback failure")
+						end,
+					})
+					highlights.setup()
+
+					local oil = require("oil")
+					oil.open(repo_dir)
+
+					local ready = helpers.wait_for(function()
+						return vim.bo.filetype == "oil"
+					end, 2000)
+
+					if not ready then
+						return
+					end
+
+					local bufnr = vim.api.nvim_get_current_buf()
+					helpers.wait_for_oil_entries(bufnr, 2000)
+
+					assert.has_no.errors(function()
+						highlights.apply(bufnr, repo_dir .. "/")
+					end)
+				end)
+			end)
 
 			describe("untracked and ignored inheritance", function()
 				local repo_dir


### PR DESCRIPTION
## Problem

oil.nvim sets `signcolumn=no` by default. The plugin's internal check sees this and falls back to eol virtual text, which means `sign_text` extmarks are never placed. This makes it impossible to use `symbol_position = 'signcolumn'` without overriding oil's `win_options`.

Users with custom `statuscolumn` expressions need `sign_text` extmarks placed so they can render signs at a width of their choosing (Neovim's native sign column is hardcoded to 2 cells per sign). Users with native signcolumn need the plugin to set `vim.wo.signcolumn` for them.

## Solution

Add a `can_use_signcolumn` callback that overrides the internal signcolumn check. The return value controls behavior:

- **`true`** (boolean): place `sign_text` extmarks, don't manage `vim.wo.signcolumn`. For users who render signs themselves via a custom `statuscolumn`.
- **String** (e.g. `'yes'`, `'auto:2'`): place `sign_text` extmarks AND set `vim.wo.signcolumn` to the returned value. For users who want the plugin to manage signcolumn.
- **`nil`/`false`**: fall through to the internal check (existing behavior).

Also fixes multi-byte sign truncation (`strcharpart` instead of `sub`).