### PR TITLE
fix: support git paths with spaces

### DIFF
--- a/lua/oil-git/git.lua
+++ b/lua/oil-git/git.lua
@@ -245,39 +245,36 @@ local function parse_output(output, git_root)
 	local status = {}
 	local status_trie = trie.create_node()
 
-	for line in output:gmatch("[^\r\n]+") do
-		if #line < 4 then
-			goto continue
-		end
+	local records = vim.split(output, "\0", { plain = true, trimempty = true })
+	local index = 1
 
-		local status_code = line:sub(1, 2)
-		local filepath = line:sub(4)
+	while index <= #records do
+		local record = records[index]
+		if #record >= 4 then
+			local status_code = record:sub(1, 2)
+			local filepath = record:sub(4)
 
-		if not filepath or filepath == "" then
-			goto continue
-		end
+			if filepath ~= "" then
+				if status_code:sub(1, 1) == "R" or status_code:sub(1, 1) == "C" then
+					index = index + 1
+				end
 
-		if status_code:sub(1, 1) == "R" or status_code:sub(1, 1) == "C" then
-			local arrow_pos = filepath:find(" %-> ")
-			if arrow_pos then
-				filepath = filepath:sub(arrow_pos + 4)
+				if filepath:sub(1, 2) == "./" then
+					filepath = filepath:sub(3)
+				end
+
+				local is_directory = filepath:sub(-1) == "/"
+
+				filepath = path.git_to_os(filepath)
+				local abs_path = path.join(git_root, filepath)
+				abs_path = path.remove_trailing_slash(abs_path)
+
+				status[abs_path] = status_code
+				trie.insert(status_trie, abs_path, status_code, git_root, is_directory)
 			end
 		end
 
-		if filepath:sub(1, 2) == "./" then
-			filepath = filepath:sub(3)
-		end
-
-		local is_directory = filepath:sub(-1) == "/"
-
-		filepath = path.git_to_os(filepath)
-		local abs_path = path.join(git_root, filepath)
-		abs_path = path.remove_trailing_slash(abs_path)
-
-		status[abs_path] = status_code
-		trie.insert(status_trie, abs_path, status_code, git_root, is_directory)
-
-		::continue::
+		index = index + 1
 	end
 
 	return status, status_trie
@@ -319,7 +316,7 @@ function M.get_status_async(dir, callback)
 		local stdout = uv.new_pipe(false)
 		local output_parts = {}
 
-		local args = { "status", "--porcelain" }
+		local args = { "status", "--porcelain=v1", "-z" }
 		if include_ignored then
 			table.insert(args, "--ignored")
 		end

--- a/lua/oil-git/git.lua
+++ b/lua/oil-git/git.lua
@@ -245,7 +245,10 @@ local function parse_output(output, git_root)
 	local status = {}
 	local status_trie = trie.create_node()
 
-	local records = vim.split(output, "\0", { plain = true, trimempty = true })
+	local records = vim.split(output, "\0", {
+		plain = true,
+		trimempty = true,
+	})
 	local index = 1
 
 	while index <= #records do
@@ -255,7 +258,10 @@ local function parse_output(output, git_root)
 			local filepath = record:sub(4)
 
 			if filepath ~= "" then
-				if status_code:sub(1, 1) == "R" or status_code:sub(1, 1) == "C" then
+				if
+					status_code:sub(1, 1) == "R"
+					or status_code:sub(1, 1) == "C"
+				then
 					index = index + 1
 				end
 

--- a/tests/plenary/git_spec.lua
+++ b/tests/plenary/git_spec.lua
@@ -334,15 +334,15 @@ describe("git", function()
 			end
 
 			assert.same(
-				{ "status", "--porcelain" },
+				{ "status", "--porcelain=v1", "-z" },
 				capture_args({ debug = false })
 			)
 			assert.same(
-				{ "status", "--porcelain", "--ignored" },
+				{ "status", "--porcelain=v1", "-z", "--ignored" },
 				capture_args({ debug = false, show_ignored_files = true })
 			)
 			assert.same(
-				{ "status", "--porcelain", "--ignored" },
+				{ "status", "--porcelain=v1", "-z", "--ignored" },
 				capture_args({ debug = false, show_ignored_directories = true })
 			)
 
@@ -419,6 +419,37 @@ describe("git", function()
 			local file_path = repo_dir .. "/untracked.lua"
 			assert.is_not_nil(result_status[file_path])
 			assert.equals("??", result_status[file_path])
+
+			helpers.cleanup(repo_dir)
+		end)
+
+		it("should detect paths containing spaces", function()
+			local repo_dir = helpers.create_temp_git_repo()
+			helpers.create_and_commit_file(
+				repo_dir,
+				"directory with spaces/file with spaces.lua",
+				"-- original content"
+			)
+			helpers.create_file(
+				repo_dir,
+				"directory with spaces/file with spaces.lua",
+				"-- modified content"
+			)
+
+			local done = false
+			local result_status
+
+			git.get_status_async(repo_dir, function(status)
+				result_status = status
+				done = true
+			end)
+
+			helpers.wait_for(function()
+				return done
+			end)
+
+			local file_path = repo_dir .. "/directory with spaces/file with spaces.lua"
+			assert.equals(" M", result_status[file_path])
 
 			helpers.cleanup(repo_dir)
 		end)

--- a/tests/plenary/git_spec.lua
+++ b/tests/plenary/git_spec.lua
@@ -448,7 +448,8 @@ describe("git", function()
 				return done
 			end)
 
-			local file_path = repo_dir .. "/directory with spaces/file with spaces.lua"
+			local file_path = repo_dir
+				.. "/directory with spaces/file with spaces.lua"
 			assert.equals(" M", result_status[file_path])
 
 			helpers.cleanup(repo_dir)


### PR DESCRIPTION
## What changed

- Use Git's NUL-delimited porcelain output.
- Parse paths without quote handling issues.
- Support rename and copy records.
- Add regression coverage for paths containing spaces.

## Why

Git quotes paths containing spaces in normal porcelain output.
This prevented oil-git.nvim from matching Git statuses to Oil entries.

## Testing

- `make test`
- All tests pass.